### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ ciftools-java 0.8.0
     * schema support also during CifFile building
 
 ### Breaking API changes
+* not compatible with java 8 anymore
 * detaches CIF model from any schema - type-safe access now requires to specify SchemaProvider
 * several package and class names changed
 


### PR DESCRIPTION
I've just found that from 0.8.0 ciftools-java won't work in a java 8 project. This should clarify it.