### PR TITLE
Assert empty categories don't result in null values in bcif map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CIFTools Changelog
 
 This project uses semantic versioning. Furthermore, this project provides code that was generated from schemata. Any schema change that introduces a breaking change in the generated code is considered as breaking for the whole project. Additional information is provided below when this occurs (named `Breaking schema changes`). Most of these occur in experimental categories and are unlikely to affect your code. `Breaking API changes` will be avoided starting with version 1.0.0.
 
+Unreleased
+-------------
+### Bug fixes
+* BCIF writing: fix behavior when the model contains empty categories
+
 ciftools-java 7.0.1 - March 2025
 -------------
 ### Bug fixes

--- a/src/main/java/org/rcsb/cif/binary/BinaryCifWriter.java
+++ b/src/main/java/org/rcsb/cif/binary/BinaryCifWriter.java
@@ -57,6 +57,7 @@ public class BinaryCifWriter {
 
             // filter category names
             List<Category> filteredCategories = cifBlock.categories()
+                    .filter(Category::isDefined) // at least 1 row present
                     .filter(category -> options.filterCategory(category.getCategoryName()))
                     .collect(Collectors.toList());
             Object[] categories = new Object[filteredCategories.size()];
@@ -68,9 +69,6 @@ public class BinaryCifWriter {
             for (Category category : filteredCategories) {
                 String categoryName = category.getCategoryName();
                 int rowCount = category.getRowCount();
-                if (rowCount == 0) {
-                    continue;
-                }
 
                 Map<String, Object> categoryMap = new LinkedHashMap<>();
                 categoryMap.put("name", "_" + category.getCategoryName());

--- a/src/test/java/org/rcsb/cif/WriterTest.java
+++ b/src/test/java/org/rcsb/cif/WriterTest.java
@@ -21,11 +21,13 @@ import org.rcsb.cif.schema.core.CifCoreBlock;
 import org.rcsb.cif.schema.core.CifCoreFile;
 import org.rcsb.cif.schema.mm.MmCifBlock;
 import org.rcsb.cif.schema.mm.MmCifFile;
+import org.rcsb.cif.schema.mm.PdbxStructModResidue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -256,5 +258,18 @@ class WriterTest {
                 .as(StandardSchemata.MMCIF);
         assertEquals("0197355516942160", cifFile.getFirstBlock().getMaTargetRefDbDetails().getSeqDbSequenceChecksum().get(0));
         assertNotNull(CifIO.writeBinary(cifFile));
+    }
+
+    @Test
+    void whenEmptyCategory_thenNotWritten() throws IOException {
+        MmCifFile cifFile = CifIO.readFromInputStream(TestHelper.getInputStream("bcif/1acj.bcif.gz")).as(StandardSchemata.MMCIF);
+        MmCifBlock block = cifFile.getFirstBlock();
+        PdbxStructModResidue modResidue = block.getPdbxStructModResidue(); // this access adds an empty to the block
+        assertFalse(modResidue.isDefined(), "category should be undefined");
+
+        byte[] text = CifIO.writeText(cifFile);
+        assertFalse(CifIO.readFromInputStream(new ByteArrayInputStream(text)).as(StandardSchemata.MMCIF).getFirstBlock().getPdbxStructModResidue().isDefined());
+        byte[] binary = CifIO.writeBinary(cifFile);
+        assertFalse(CifIO.readFromInputStream(new ByteArrayInputStream(binary)).as(StandardSchemata.MMCIF).getFirstBlock().getPdbxStructModResidue().isDefined());
     }
 }


### PR DESCRIPTION
Access to categories may create empty categories if no data is present, e.g. when invoking `getPdbxStructModResidue()` for entries without modified residues.
These empty categories weren't properly filtered when writing BinaryCIF, leading to a mismatch between the allocated number of categories and the actually written data.

This PR adds a test for that behavior (without the fix writing seems OK but files fail to open) and hardens the filtering rules for categories.